### PR TITLE
default to using empty Redis password

### DIFF
--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -72,8 +72,7 @@ redis:
     storageClass: redis
     accessMode: ReadWriteOnce
     size: 8Gi
-  usePassword: true
-  redisPassword:
+  usePassword: false
 
 ## Ingress configuration.
 ## ref: https://kubernetes.io/docs/user-guide/ingress/


### PR DESCRIPTION
By setting `usePassword` to false, the Redis Helm chart should allow an empty password (https://github.com/kubernetes/charts/blob/master/stable/redis/templates/deployment.yaml#L43-L52). 

Prior to this, the fn-api pods were spitting out auth errors from Redis:
`level=error msg="error fetching queued calls" error="NOAUTH Authentication required."`

In addition, sync functions worked while async didn't (because of Redis). This fixes that issue.