### PR TITLE
Add option to split worker/api nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ helm delete --purge my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
-## Configuration 
+## Configuration
 
 |  Key                           |  Description                      |  Default              |
 | -------------------------------|-----------------------------------|-----------------------|
 | `fn.service.type`        | ClusterIP, NodePort, LoadBalancer | `LoadBalancer`        |
 | `fn.service.port`        | Fn service port                   | `80`                  |
+| `fn.service.splitWorkers` | Whether to split worker/api nodes | `false`               |
 | `fn.service.annotations` | Fn Service annotations            | `{}`                  |
 | `fnserver.resources`           | Per-node resource requests, see [Kubernetes Pod Resources](http://kubernetes.io/docs/user-guide/compute-resources/)            | `{}`                  |
 | `fnserver.nodeSelector`        | Fn node selectors, see [Kubernetes Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`                  |
@@ -70,15 +71,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ui.service.type`              | UI Service type                   | `LoadBalancer`        |
 | `mysql.*`                      | See the [MySQL chart docs](https://github.com/kubernetes/charts/tree/master/stable/mysql) | |
 | `redis.*`                      | See the [Redis chart docs](https://github.com/kubernetes/charts/tree/master/stable/redis) | |
- 
- ## Configuring Database Persistence 
- 
+
+ ## Configuring Database Persistence
+
 Fn persists application data in MySQL. This is configured using the MySQL Helm Chart.
 
 By default this uses container storage. To configure a persistent volume, set `mysql.*` values in the chart values to that which corresponds to your storage requirements.
 
 e.g. to use an existing persistent volume claim for MySQL storage:
 
-```bash 
+```bash
 helm install --name testfn --set mysql.persistence.enabled=true,mysql.persistence.existingClaim=tc-fn-mysql fn
 ```

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------|-----------------------------------|-----------------------|
 | `fn.service.type`        | ClusterIP, NodePort, LoadBalancer | `LoadBalancer`        |
 | `fn.service.port`        | Fn service port                   | `80`                  |
-| `fn.service.splitWorkers` | Whether to split worker/api nodes | `false`               |
 | `fn.service.annotations` | Fn Service annotations            | `{}`                  |
+| `fnserver.splitWorkers`  | Whether to split worker/api nodes | `false`               |
 | `fnserver.resources`           | Per-node resource requests, see [Kubernetes Pod Resources](http://kubernetes.io/docs/user-guide/compute-resources/)            | `{}`                  |
 | `fnserver.nodeSelector`        | Fn node selectors, see [Kubernetes Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`                  |
 | `fnserver.tolerations`         | Node taint tolerations, see [Kubernetes Taints and Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`             |

--- a/fn/Chart.yaml
+++ b/fn/Chart.yaml
@@ -1,6 +1,6 @@
 name: fn
-version: 0.1.0
-appVersion: 0.0.161
+version: 0.2.0
+appVersion: 0.0.276
 description: Open source container native Functions as a Service (FaaS) platform
 keywords:
 - faas
@@ -20,4 +20,6 @@ maintainers:
   email: derek.schultz@oracle.com
 - name: Owen Cliffe
   email: owen.cliffe@oracle.com
+- name: Dario Domizioli
+  email: dario.domizioli@oracle.com
 engine: gotpl

--- a/fn/templates/NOTES.txt
+++ b/fn/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if not .Values.fn.service.splitWorkers }}
 The Fn service can be accessed within your cluster at:
 
  - http://{{template  "fullname" .}}-api.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
@@ -28,6 +29,49 @@ Then set
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-service" -o jsonpath="{.items[0].metadata.name}")
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:80 &
     export FN_API_URL=http://127.0.0.1:8080
+{{- end }}
+
+{{- else if .Values.fn.service.splitWorkers }}
+The Fn service API and runners can be accessed within your cluster at:
+
+ - http://{{template  "fullname" .}}-api.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
+ - http://{{template  "fullname" .}}-runner.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
+
+Set these environment variables to use the Fn service from outside the cluster:
+
+{{- if contains "NodePort" .Values.fn.service.type }}
+
+    export FN_API_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-api)
+    export FN_API_NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export FN_RUNNER_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-runner)
+    export FN_RUNNER_NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+
+    export FN_API_URL=http://$FN_API_NODE_IP:$FN_API_NODE_PORT
+    export FN_RUNNER_URL=http://$FN_RUNNER_NODE_IP:$FN_RUNNER_NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.fn.service.type }}
+
+!! NOTE: It may take a few minutes for the API load balancer to become available.
+
+You can watch for EXTERNAL-IP to populate by running:
+
+  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}-api
+  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}-runner
+
+Then set
+
+    export FN_API_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-api -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
+    export FN_RUNNER_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-runner -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
+
+{{- else if contains "ClusterIP" .Values.fn.service.type }}
+
+    export FN_API_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-service" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward --namespace {{ .Release.Namespace }} $FN_API_POD_NAME 8080:80 &
+    export FN_RUNNER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-runner" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward --namespace {{ .Release.Namespace }} $FN_API_POD_NAME 8081:80 &
+    export FN_RUNNER_URL=http://127.0.0.1:8081
+{{- end }}
+
 {{- end }}
 
 

--- a/fn/templates/NOTES.txt
+++ b/fn/templates/NOTES.txt
@@ -2,7 +2,7 @@ The Fn service API can be accessed within your cluster at:
 
  - http://{{template  "fullname" .}}-api.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
 
-Set the FN_API_URL environment variable to this address to use the Fn service from outside the cluster:
+Set these environment variables to use the Fn service from outside the cluster:
 
 {{- if contains "NodePort" .Values.fn.service.type }}
 
@@ -32,6 +32,12 @@ Then set
     export FN_API_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-api -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
 
 {{- if .Values.fnserver.splitWorkers }}
+Similarly, you can watch for the EXTERNAL-IP of the runner URL:
+
+  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}-runner
+
+Then set
+
     export FN_RUNNER_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-runner -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
 
 App/function routes are reachable under $FN_RUNNER_URL/r/

--- a/fn/templates/NOTES.txt
+++ b/fn/templates/NOTES.txt
@@ -1,5 +1,4 @@
-{{- if not .Values.fn.service.splitWorkers }}
-The Fn service can be accessed within your cluster at:
+The Fn service API can be accessed within your cluster at:
 
  - http://{{template  "fullname" .}}-api.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
 
@@ -12,6 +11,14 @@ Set the FN_API_URL environment variable to this address to use the Fn service fr
 
     export FN_API_URL=http://$NODE_IP:$NODE_PORT
 
+{{- if .Values.fnserver.splitWorkers }}
+    export RUNNER_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-api)
+    export FN_RUNNER_URL=http://$NODE_IP:$RUNNER_NODE_PORT
+
+App/function routes are reachable under $FN_RUNNER_URL/r/
+
+{{- end }}
+
 {{- else if contains "LoadBalancer" .Values.fn.service.type }}
 
 !! NOTE: It may take a few minutes for the API load balancer to become available.
@@ -23,57 +30,30 @@ You can watch for EXTERNAL-IP to populate by running:
 Then set
 
     export FN_API_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-api -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
+
+{{- if .Values.fnserver.splitWorkers }}
+    export FN_RUNNER_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-runner -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
+
+App/function routes are reachable under $FN_RUNNER_URL/r/
+
+{{- end }}
 
 {{- else if contains "ClusterIP" .Values.fn.service.type }}
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-service" -o jsonpath="{.items[0].metadata.name}")
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:80 &
     export FN_API_URL=http://127.0.0.1:8080
-{{- end }}
 
-{{- else if .Values.fn.service.splitWorkers }}
-The Fn service API and runners can be accessed within your cluster at:
-
- - http://{{template  "fullname" .}}-api.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
- - http://{{template  "fullname" .}}-runner.{{ .Release.Namespace }}:{{ .Values.fn.service.port}}
-
-Set these environment variables to use the Fn service from outside the cluster:
-
-{{- if contains "NodePort" .Values.fn.service.type }}
-
-    export FN_API_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-api)
-    export FN_API_NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export FN_RUNNER_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-runner)
-    export FN_RUNNER_NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-
-    export FN_API_URL=http://$FN_API_NODE_IP:$FN_API_NODE_PORT
-    export FN_RUNNER_URL=http://$FN_RUNNER_NODE_IP:$FN_RUNNER_NODE_PORT
-
-{{- else if contains "LoadBalancer" .Values.fn.service.type }}
-
-!! NOTE: It may take a few minutes for the API load balancer to become available.
-
-You can watch for EXTERNAL-IP to populate by running:
-
-  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}-api
-  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}-runner
-
-Then set
-
-    export FN_API_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-api -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
-    export FN_RUNNER_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-runner -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
-
-{{- else if contains "ClusterIP" .Values.fn.service.type }}
-
-    export FN_API_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-service" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $FN_API_POD_NAME 8080:80 &
-    export FN_RUNNER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-runner" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $FN_API_POD_NAME 8081:80 &
+{{- if .Values.fnserver.splitWorkers }}
+    export RUNNER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=fn-runner" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8081:80 &
     export FN_RUNNER_URL=http://127.0.0.1:8081
-{{- end }}
+
+App/function routes are reachable under $FN_RUNNER_URL/r/
 
 {{- end }}
 
+{{- end }}
 
 {{- if not  .Values.mysql.persistence.enabled }}
 

--- a/fn/templates/NOTES.txt
+++ b/fn/templates/NOTES.txt
@@ -32,6 +32,7 @@ Then set
     export FN_API_URL=http://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-api -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.fn.service.port }}
 
 {{- if .Values.fnserver.splitWorkers }}
+
 Similarly, you can watch for the EXTERNAL-IP of the runner URL:
 
   kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}-runner

--- a/fn/templates/flow-deployment.yaml
+++ b/fn/templates/flow-deployment.yaml
@@ -46,5 +46,12 @@ spec:
             value: {{ .Release.Name }}-mysql
           - name: DB_URL
             value: mysql://fnapp:$(DB_PASSWD)@tcp($(DB_HOST):3306)/fndb
+          # In a split workers scenario we use the runner service directly.
+          # Otherwise we can use the api service which will go through the fnlb anyway.
+          {{- if .Values.fnserver.splitWorkers }}
+          - name: API_URL
+            value: http://{{ template "fullname" . }}-runner
+          {{- else }}
           - name: API_URL
             value: http://{{ template "fullname" . }}-api
+{{- end }}

--- a/fn/templates/fn-daemonset.yaml
+++ b/fn/templates/fn-daemonset.yaml
@@ -120,7 +120,7 @@ spec:
         - name: FN_NODE_TYPE
           value: runner
         - name: FN_RUNNER_API_URL
-          value: {{ template "fullname" . }}-api
+          value: http://{{ template "fullname" . }}-api
         - name: LOG_LEVEL
           value: {{ .Values.fnserver.logLevel }}
         - name: FN_PORT

--- a/fn/templates/fn-daemonset.yaml
+++ b/fn/templates/fn-daemonset.yaml
@@ -42,6 +42,10 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 3
         env:
+        {{- if .Values.fnserver.splitWorkers }}
+        - name: FN_NODE_TYPE
+          value: api
+{{- end }}
         - name: LOG_LEVEL
           value: {{ .Values.fnserver.logLevel }}
         - name: FN_PORT
@@ -65,3 +69,60 @@ spec:
 #              key: redis-password
         - name: FN_MQ_URL
           value: redis://$(FN_MQ_HOST):6379/
+
+{{- if .Values.fnserver.splitWorkers }}
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}-runner
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        role: fn-runner
+    spec:
+      {{- if .Values.fnserver.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.fnserver.nodeSelector | indent 8 }}
+{{- end }}
+      {{- if .Values.fnserver.tolerations }}
+      tolerations:
+{{ toYaml .Values.fnserver.tolerations | indent 8 }}
+{{- end }}
+      containers:
+      - name: fn-runner
+        image: {{ .Values.fnserver.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.fnserver.resources | indent 12 }}
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        env:
+        - name: FN_NODE_TYPE
+          value: runner
+        - name: FN_RUNNER_API_URL
+          value: {{ template "fullname" . }}-api
+        - name: LOG_LEVEL
+          value: {{ .Values.fnserver.logLevel }}
+        - name: FN_PORT
+          value: "80"
+{{- end }}

--- a/fn/templates/fn-service.yaml
+++ b/fn/templates/fn-service.yaml
@@ -19,4 +19,38 @@ spec:
     targetPort: 8081
   selector:
     app: {{ template "fullname" . }}
+    # In a split workers scenario this service targets the api nodes only.
+    # Otherwise, we go through the fnlb because everything goes through here.
+    {{- if .Values.fnserver.splitWorkers }}
+    role: fn-service
+    {{- else }}
     role: fn-lb
+{{- end }}
+
+{{- if .Values.fnserver.splitWorkers }}
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-runner
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.fn.service.annotations }}
+  annotations:
+{{ toYaml .Values.fn.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.fn.service.type }}
+  ports:
+  - name: fn
+    port: {{ .Values.fn.service.port }}
+    targetPort: 8081
+  selector:
+    app: {{ template "fullname" . }}
+    # Calls to the runners always go through the fnlb.
+    role: fn-lb
+{{- end }}

--- a/fn/templates/fn-service.yaml
+++ b/fn/templates/fn-service.yaml
@@ -14,15 +14,21 @@ metadata:
 spec:
   type: {{ .Values.fn.service.type }}
   ports:
+  {{- if .Values.fnserver.splitWorkers }}
+  # In a split workers scenario this service targets the api nodes only and directly.
+  - name: fn
+    port: {{ .Values.fn.service.port }}
+    targetPort: 80
+  selector:
+    app: {{ template "fullname" . }}
+    role: fn-service
+  {{- else }}
+  # In the normal scenario this service goes through the fnlb.
   - name: fn
     port: {{ .Values.fn.service.port }}
     targetPort: 8081
   selector:
     app: {{ template "fullname" . }}
-    {{- if .Values.fnserver.splitWorkers }}
-    # In a split workers scenario this service targets the api nodes only.
-    role: fn-service
-    {{- else }}
     role: fn-lb
 {{- end }}
 
@@ -44,12 +50,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.fn.service.type }}
+  # Calls to the runners always go through the fnlb.
   ports:
   - name: fn
     port: {{ .Values.fn.service.port }}
     targetPort: 8081
   selector:
     app: {{ template "fullname" . }}
-    # Calls to the runners always go through the fnlb.
     role: fn-lb
 {{- end }}

--- a/fn/templates/fn-service.yaml
+++ b/fn/templates/fn-service.yaml
@@ -19,9 +19,8 @@ spec:
     targetPort: 8081
   selector:
     app: {{ template "fullname" . }}
-    # In a split workers scenario this service targets the api nodes only.
-    # Otherwise, we go through the fnlb because everything goes through here.
     {{- if .Values.fnserver.splitWorkers }}
+    # In a split workers scenario this service targets the api nodes only.
     role: fn-service
     {{- else }}
     role: fn-lb

--- a/fn/templates/fnlb-deployment.yaml
+++ b/fn/templates/fnlb-deployment.yaml
@@ -40,8 +40,8 @@ spec:
             value: http://{{ template "fullname" . }}-api
           args:
           - "-db=k8s"
-          # In a split workers scenario the fnlb only deals with calls to the workers.
           {{- if .Values.fnserver.splitWorkers }}
+          # In a split workers scenario the fnlb only deals with calls to the workers.
           - "-label-selector=app={{ template "fullname" . }},role=fn-runner"
           {{- else }}
           - "-label-selector=app={{ template "fullname" . }},role=fn-service"

--- a/fn/templates/fnlb-deployment.yaml
+++ b/fn/templates/fnlb-deployment.yaml
@@ -40,7 +40,12 @@ spec:
             value: http://{{ template "fullname" . }}-api
           args:
           - "-db=k8s"
+          # In a split workers scenario the fnlb only deals with calls to the workers.
+          {{- if .Values.fnserver.splitWorkers }}
+          - "-label-selector=app={{ template "fullname" . }},role=fn-runner"
+          {{- else }}
           - "-label-selector=app={{ template "fullname" . }},role=fn-service"
+{{- end }}
           - "-listen=:8081"
           - "-mgmt-listen=:8082"
           - "-target-port=80"

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -13,6 +13,7 @@ fnlb:
 fnserver:
   image: fnproject/fnserver:latest
   logLevel: info
+  splitWorkers: false
   resources: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
This change adds a configuration option `fnserver.splitWorkers` which splits the Fn service nodes into API nodes and worker ("runner") nodes.

When this option is set to true, the API service load-balances directly to the API nodes, whereas the runner service load-balances to the FnLB which then balances to the worker nodes. Communication between the nodes is wired up accordingly.

There is no change compared to the previous behavior in the default (false) case.