### PR TITLE
Set up a database using the mysql-operator

### DIFF
--- a/fn/requirements.lock
+++ b/fn/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.0.4
-digest: sha256:73453f3ea36101717bc4cf35edd010a063cae7fd646c00d318adf52fc806fd24
-generated: 2017-11-23T18:20:04.411674542Z
+digest: sha256:48f0642f59921309bb7625c8b83365e57ad8e1ac343e940f1738528ff2c8f5b8
+generated: 2018-01-10T15:08:46.155858Z

--- a/fn/requirements.yaml
+++ b/fn/requirements.yaml
@@ -2,6 +2,7 @@ dependencies:
 - name: mysql
   version: 0.3.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mysql.enabled
 - name: redis
   version: 1.0.4
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/fn/templates/flow-deployment.yaml
+++ b/fn/templates/flow-deployment.yaml
@@ -45,6 +45,40 @@ spec:
           - name: DB_HOST
             value: {{ .Release.Name }}-mysql
           - name: DB_URL
+{{ if .Values.mysql_operator.enabled }}
+            value: mysql://fnapp:$(DB_PASSWD)@tcp(127.0.0.1:6446)/fndb
+{{ else }}
             value: mysql://fnapp:$(DB_PASSWD)@tcp($(DB_HOST):3306)/fndb
+{{ end }}
           - name: API_URL
             value: http://{{ template "fullname" . }}-api
+
+{{ if .Values.mysql_operator.enabled }}
+        # Add the mysql helper
+        - name: mysqlrouter
+          image: pulsepointinc/mysql-router:2.1.3
+          env:
+          - name: DB_ROOT_PASSWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-mysql-root-password
+                key: password
+          - name: FN_DB_PASSWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-mysql
+                key: mysql-password
+          - name: FN_DB_HOST
+            value: {{ .Release.Name }}-mysql
+          command:
+          - "/bin/bash"
+          - "-cx"
+          - |
+            set -e
+            echo "Bootstraping the router"
+            echo $DB_ROOT_PASSWD | mysqlrouter --bootstrap $FN_DB_HOST-0.$FN_DB_HOST:3306 --user=root
+            search=$(grep search /etc/resolv.conf)
+            echo "$search $FN_DB_HOST.{{ .Release.Namespace }}.svc.cluster.local" >> /etc/resolv.conf
+            echo "Running the router"
+            mysqlrouter --user=root
+{{ end }}

--- a/fn/templates/fn-daemonset.yaml
+++ b/fn/templates/fn-daemonset.yaml
@@ -54,7 +54,11 @@ spec:
         - name: FN_DB_HOST
           value: {{ .Release.Name }}-mysql
         - name: FN_DB_URL
+{{ if .Values.mysql_operator.enabled }}
+          value: mysql://fnapp:$(FN_DB_PASSWD)@tcp(127.0.0.1:6446)/fndb
+{{ else }}
           value: mysql://fnapp:$(FN_DB_PASSWD)@tcp($(FN_DB_HOST):3306)/fndb
+{{ end }}
         - name: FN_MQ_HOST
           value: {{ .Release.Name }}-redis
 #  TODO:
@@ -65,3 +69,32 @@ spec:
 #              key: redis-password
         - name: FN_MQ_URL
           value: redis://$(FN_MQ_HOST):6379/
+{{ if .Values.mysql_operator.enabled }}
+      # Add the mysql helper
+      - name: mysqlrouter
+        image: pulsepointinc/mysql-router:2.1.3
+        env:
+        - name: DB_ROOT_PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-mysql-root-password
+              key: password
+        - name: FN_DB_PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-mysql
+              key: mysql-password
+        - name: FN_DB_HOST
+          value: {{ .Release.Name }}-mysql
+        command:
+        - "/bin/bash"
+        - "-cx"
+        - |
+          set -e
+          echo "Bootstraping the router"
+          echo $DB_ROOT_PASSWD | mysqlrouter --bootstrap $FN_DB_HOST-0.$FN_DB_HOST:3306 --user=root
+          search=$(grep search /etc/resolv.conf)
+          echo "$search $FN_DB_HOST.{{ .Release.Namespace }}.svc.cluster.local" >> /etc/resolv.conf
+          echo "Running the router"
+          mysqlrouter --user=root
+{{ end }}

--- a/fn/templates/fnlb-deployment.yaml
+++ b/fn/templates/fnlb-deployment.yaml
@@ -44,3 +44,16 @@ spec:
           - "-listen=:8081"
           - "-mgmt-listen=:8082"
           - "-target-port=80"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fnlb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}

--- a/fn/templates/mysql-job.yaml
+++ b/fn/templates/mysql-job.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.mysql_operator.enabled -}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-mysql-init
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  template:
+    metadata:
+      name: {{ template "fullname" . }}-mysql-init
+      labels:
+        app: {{ template "fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        role: mysql-init
+    spec:
+      containers:
+      - name: c
+        image: mysql
+        command: 
+        - "bash"
+        - "-c"
+        - |
+          set -ex
+          printenv
+          sleep 30
+          mysqladmin -h {{ .Release.Name }}-mysql --user=root --password=$DB_ROOT_PASSWD ping
+          mysql -h {{ .Release.Name }}-mysql --user=root --password=$DB_ROOT_PASSWD --batch --skip-column-names <<-EOF
+          	create database if not exists $DB_DATABASE;
+          	grant all privileges on $DB_DATABASE.* to '$DB_USER'@'%' identified by '$DB_PASSWD';
+          	flush privileges;
+          	EOF
+        env:
+          - name: DB_PASSWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-mysql
+                key: mysql-password
+          - name: DB_ROOT_PASSWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-mysql-root-password
+                key: password
+          - name: DB_HOST
+            value: {{ .Release.Name }}-mysql
+          - name: DB_DATABASE
+            value: fndb
+          - name: DB_USER
+            value: fnapp
+      restartPolicy: Never
+  backoffLimit: 600
+
+{{ end -}}

--- a/fn/templates/mysql-job.yaml
+++ b/fn/templates/mysql-job.yaml
@@ -30,11 +30,12 @@ spec:
           set -ex
           printenv
           sleep 30
-          mysqladmin -h {{ .Release.Name }}-mysql --user=root --password=$DB_ROOT_PASSWD ping
-          mysql -h {{ .Release.Name }}-mysql --user=root --password=$DB_ROOT_PASSWD --batch --skip-column-names <<-EOF
+          mysqladmin -h {{ .Release.Name }}-mysql-0.{{ .Release.Name }}-mysql --user=root --password=$DB_ROOT_PASSWD ping
+          mysql -h {{ .Release.Name }}-mysql-0.{{ .Release.Name }}-mysql --user=root --password=$DB_ROOT_PASSWD --batch --skip-column-names <<-EOF
           	create database if not exists $DB_DATABASE;
           	grant all privileges on $DB_DATABASE.* to '$DB_USER'@'%' identified by '$DB_PASSWD';
           	flush privileges;
+          	show databases;
           	EOF
         env:
           - name: DB_PASSWD

--- a/fn/templates/mysql-operator.yaml
+++ b/fn/templates/mysql-operator.yaml
@@ -20,15 +20,18 @@ spec:
   backupTemplate:
     clusterRef:
       name: {{ .Release.Name }}-mysql
-    databases:
-      - fndb
-    provider: s3
-    config:
-      endpoint: {{ .Values.mysql_operator.backup.endpoint }}
-      region: {{ .Values.mysql_operator.backup.region }}
-      bucket: {{ .Values.mysql_operator.backup.bucket }}
-    secretRef:
-      name: {{ .Release.Name }}-mysql-backup
+    executor:
+      provider: mysqldump
+      databases:
+        - fndb
+    storage:
+      provider: s3
+      secretRef:
+        name: {{ .Release.Name }}-mysql-backup
+      config:
+        endpoint: {{ .Values.mysql_operator.backup.endpoint }}
+        region: {{ .Values.mysql_operator.backup.region }}
+        bucket: {{ .Values.mysql_operator.backup.bucket }}
 
 {{ end -}}
 {{ end -}}

--- a/fn/templates/mysql-operator.yaml
+++ b/fn/templates/mysql-operator.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Release.Name }}-mysql
 spec:
   replicas: {{ .Values.mysql_operator.replicas }}
+  multiMaster: true
 
 ---
 

--- a/fn/templates/mysql-operator.yaml
+++ b/fn/templates/mysql-operator.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.mysql_operator.enabled -}}
+
+apiVersion: mysql.oracle.com/v1
+kind: MySQLCluster
+metadata:
+  name: {{ .Release.Name }}-mysql
+spec:
+  replicas: {{ .Values.mysql_operator.replicas }}
+
+---
+
+{{- if .Values.mysql_operator.backup.enabled -}}
+
+apiVersion: "mysql.oracle.com/v1"
+kind: MySQLBackupSchedule
+metadata:
+  name: {{ .Release.Name }}-mysql-backup-schedule
+spec:
+  schedule: {{ .Values.mysql_operator.backup.schedule | quote }}
+  backupTemplate:
+    clusterRef:
+      name: {{ .Release.Name }}-mysql
+    databases:
+      - fndb
+    provider: s3
+    config:
+      endpoint: {{ .Values.mysql_operator.backup.endpoint }}
+      region: {{ .Values.mysql_operator.backup.region }}
+      bucket: {{ .Values.mysql_operator.backup.bucket }}
+    secretRef:
+      name: {{ .Release.Name }}-mysql-backup
+
+{{ end -}}
+{{ end -}}

--- a/fn/templates/mysql-secrets.yaml
+++ b/fn/templates/mysql-secrets.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.mysql_operator.enabled -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-mysql
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{ if .Values.mysqlPassword }}
+  mysql-password:  {{ .Values.mysqlPassword | b64enc | quote }}
+  {{ else }}
+  mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+
+---
+
+{{- if .Values.mysql_operator.backup.enabled -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-mysql-backup
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  accessKey:  {{ .Values.mysql_operator.backup.access_key | b64enc | quote }}
+  secretKey:  {{ .Values.mysql_operator.backup.secret_key | b64enc | quote }}
+
+{{ end -}}
+{{ end -}}

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -1,6 +1,9 @@
 # Default values for Fn
 imagePullPolicy: Always
 
+# If non-null, will override the cluster name
+nameOverride: ''
+
 fn:
   service:
     port: 80
@@ -9,6 +12,8 @@ fn:
 
 fnlb:
   image: fnproject/fnlb:latest
+  logLevel: info
+  resources: {}
 
 fnserver:
   image: fnproject/fnserver:latest

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -52,6 +52,7 @@ flow:
 ## MySQL chart configuration
 ##
 mysql:
+  enabled: true
   persistence:
     enabled: false
     nodeSelector: mysql-storage
@@ -66,6 +67,27 @@ mysql:
   mysqlDatabase: fndb
   mysqlUser: fnapp
   mysqlPassword: boomsauce
+
+# The kind of installation: using the standard mysql images,
+# or the mysql-operator
+mysql_operator:
+  enabled: false
+
+  # For the moment, the database settings are taken from the mysql stanza above:
+  # mysqlDatabase
+  # mysqlUser
+  # mysqlPassword
+
+  replicas: 3
+
+  backup:
+    enabled: false
+    schedule: '*/5 * * * *'
+    endpoint: foo.bar.example.com
+    region: bar
+    bucket: backups
+    access_key: baz
+    secret_key: quux
 
 ##
 ## Redis chart configuration


### PR DESCRIPTION
This needs configuring as follows:

    helm install -f examples/minikube/values.yaml \
        --set mysql.enabled=false \
        --set mysql_operator.enabled=true \
        --name=fn-dev-svc-v0-0-161 fn

The credentials will be pulled from the mysql.* value tree; behaviour
is controlled by disabling the mysql chart and using the built-in
operator support instead.

(This chart has mysql-operator as a pre-requisite.)