### PR TITLE
A default image tag of latest needs an Always imagePullPolicy

### DIFF
--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -1,5 +1,5 @@
 # Default values for Fn
-imagePullPolicy: IfNotPresent
+imagePullPolicy: Always
 
 fn:
   service:


### PR DESCRIPTION
If users are specifying image tags explicitly, that's one thing;
but if we're depending on :latest by default, then the chart should
supply a policy that does the right thing on an upgrade.