### PR TITLE
Fn ui port change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,6 @@ jobs:
             curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | sudo bash
       - run:
           command: |
-            helm lint fn
+            helm lint --strict  fn
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,6 @@ jobs:
             curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | sudo bash
       - run:
           command: |
-            helm lint --strict  fn
+            helm lint fn
 
 

--- a/fn/templates/ui-deployment.yaml
+++ b/fn/templates/ui-deployment.yaml
@@ -27,10 +27,10 @@ spec:
           resources:
 {{ toYaml .Values.ui.fnui.resources | indent 12 }}
           ports:
-            - containerPort: 4000
+            - containerPort: {{ .Values.ui.service.fnuiPort }}
           env:
           - name: PORT
-            value: "80"
+            value: "{{ .Values.ui.service.fnuiPort }}"
           - name: FN_API_URL
             value: http://{{ template "fullname" . }}-api
         - name: flow-ui
@@ -39,7 +39,7 @@ spec:
           resources:
 {{ toYaml .Values.ui.flowui.resources | indent 12 }}
           ports:
-            - containerPort: 3000
+            - containerPort: {{ .Values.ui.service.flowuiPort }}
           env:
             - name: API_URL
               value: http://{{ template "fullname" . }}-api

--- a/fn/templates/ui-deployment.yaml
+++ b/fn/templates/ui-deployment.yaml
@@ -29,8 +29,8 @@ spec:
           ports:
             - containerPort: 4000
           env:
-          - name: FN_PORT
-            value: "4000"
+          - name: PORT
+            value: "80"
           - name: FN_API_URL
             value: http://{{ template "fullname" . }}-api
         - name: flow-ui

--- a/fn/templates/ui-service.yaml
+++ b/fn/templates/ui-service.yaml
@@ -17,11 +17,11 @@ spec:
   type: {{ .Values.ui.service.type }}
   ports:
     - name: flow-ui
-      port: {{ .Values.ui.service.flowuiPort }}
-      targetPort: 3000
-    - name: fn
-      port: {{ .Values.ui.service.fnuiPort }}
-      targetPort: 4000
+      port: {{ default "3000" .Values.ui.service.flowuiPort }}
+      targetPort: {{ default "3000" .Values.ui.service.flowuiPort }}
+    - name: fn-ui
+      port: {{ default "4000" .Values.ui.service.fnuiPort }}
+      targetPort: {{ default "4000" .Values.ui.service.fnuiPort }}
   selector:
     app: {{ template "fullname" . }}
     role: ui

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -33,7 +33,7 @@ ui:
     resources: {}
   service:
     flowuiPort: 3000
-    fnuiPort: 4000
+    fnuiPort: 80
     type: LoadBalancer
     annotations: {}
 


### PR DESCRIPTION
- Changes default port for fn-ui from `4000` to `80`
- Fixes incorrect env var for fn-ui, `FN_PORT` -> `PORT`
- Inherit values for ui service ports in templates instead of hardcoding, and provide the default values in case these are not set in `values.yaml` (which they are by default, but meh, probably good practice)