### PR TITLE
FNLB needs RBAC

### DIFF
--- a/fn/templates/fnlb-deployment.yaml
+++ b/fn/templates/fnlb-deployment.yaml
@@ -44,3 +44,16 @@ spec:
           - "-listen=:8081"
           - "-mgmt-listen=:8082"
           - "-target-port=80"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fnlb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -1,6 +1,9 @@
 # Default values for Fn
 imagePullPolicy: Always
 
+# If non-null, will override the cluster name
+nameOverride: ''
+
 fn:
   service:
     port: 80
@@ -9,6 +12,8 @@ fn:
 
 fnlb:
   image: fnproject/fnlb:latest
+  logLevel: info
+  resources: {}
 
 fnserver:
   image: fnproject/fnserver:latest


### PR DESCRIPTION
Under a k8s deployment using RBAC, the FNLB service account (which
is the namespace 'default' in this case) requires view permissions
in order to search out target FN pods.

(As a prerequisite, sort out the helm --strict linting)