### PR TITLE
Set image tags to specific versions, instead of using 'latest'

### DIFF
--- a/fn/templates/flow-deployment.yaml
+++ b/fn/templates/flow-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: flow
-          image: {{ .Values.flow.image }}
+          image: {{ .Values.flow.image }}:{{ .Values.flow.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
 {{ toYaml .Values.flow.resources | indent 12 }}

--- a/fn/templates/fn-daemonset.yaml
+++ b/fn/templates/fn-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
 {{- end }}
       containers:
       - name: fn-service
-        image: {{ .Values.fnserver.image }}
+        image: {{ .Values.fnserver.image }}:{{ .Values.fnserver.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.fnserver.resources | indent 12 }}

--- a/fn/templates/fnlb-deployment.yaml
+++ b/fn/templates/fnlb-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: fnlb
-          image: {{ .Values.fnlb.image }}
+          image: {{ .Values.fnlb.image }}:{{ .Values.fnlb.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
 {{ toYaml .Values.fnlb.resources | indent 12 }}

--- a/fn/templates/ui-deployment.yaml
+++ b/fn/templates/ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: fn-ui
-          image: {{ .Values.ui.fnui.image }}
+          image: {{ .Values.ui.fnui.image }}:{{ .Values.ui.fnui.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
 {{ toYaml .Values.ui.fnui.resources | indent 12 }}
@@ -34,7 +34,7 @@ spec:
           - name: FN_API_URL
             value: http://{{ template "fullname" . }}-api
         - name: flow-ui
-          image: {{ .Values.ui.flowui.image }}
+          image: {{ .Values.ui.flowui.image }}:{{ .Values.ui.flowui.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
 {{ toYaml .Values.ui.flowui.resources | indent 12 }}

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -11,25 +11,28 @@ fn:
     annotations: {}
 
 fnlb:
-  image: fnproject/fnlb:latest
+  image: fnproject/fnlb
+  tag: 0.0.268
   logLevel: info
   resources: {}
 
 fnserver:
-  image: fnproject/fnserver:latest
+  image: fnproject/fnserver
+  tag: 0.3.461
   logLevel: info
   resources: {}
   nodeSelector: {}
   tolerations: []
 
-
 ui:
   enabled: true
   fnui:
-    image: fnproject/ui:latest
+    image: fnproject/ui
+    tag: 0.0.26
     resources: {}
   flowui:
-    image: fnproject/flow:ui
+    image: fnproject/flow
+    tag: ui
     resources: {}
   service:
     flowuiPort: 3000
@@ -37,16 +40,15 @@ ui:
     type: LoadBalancer
     annotations: {}
 
-
 flow:
-  image: fnproject/flow:latest
+  image: fnproject/flow
+  tag: 0.1.83
   logLevel: info
   service:
     port: 80
     type: ClusterIP
     annotations: {}
   resources: {}
-
 
 ##
 ## MySQL chart configuration


### PR DESCRIPTION
Break the image name into 'name' and 'tag' and lock down tag to the actual version number, instead of latest. Fixes #23 