### PR TITLE
Extract environment variables for fnserver to the values.yaml file

### DIFF
--- a/fn/templates/fn-daemonset.yaml
+++ b/fn/templates/fn-daemonset.yaml
@@ -42,10 +42,12 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 3
         env:
-        - name: LOG_LEVEL
-          value: {{ .Values.fnserver.logLevel }}
-        - name: FN_PORT
-          value: "80"
+        {{- range $key, $value := .Values.fnserver.env }}
+          {{- if $value }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
         - name: FN_DB_PASSWD
           valueFrom:
             secretKeyRef:
@@ -53,8 +55,6 @@ spec:
               key: mysql-password
         - name: FN_DB_HOST
           value: {{ .Release.Name }}-mysql
-        - name: FN_DB_URL
-          value: mysql://fnapp:$(FN_DB_PASSWD)@tcp($(FN_DB_HOST):3306)/fndb
         - name: FN_MQ_HOST
           value: {{ .Release.Name }}-redis
 #  TODO:
@@ -63,5 +63,3 @@ spec:
 #            secretKeyRef:
 #              name: {{ .Release.Name }}-redis
 #              key: redis-password
-        - name: FN_MQ_URL
-          value: redis://$(FN_MQ_HOST):6379/

--- a/fn/templates/fn-daemonset.yaml
+++ b/fn/templates/fn-daemonset.yaml
@@ -44,8 +44,8 @@ spec:
         env:
         {{- range $key, $value := .Values.fnserver.env }}
           {{- if $value }}
-          - name: {{ $key }}
-            value: {{ $value | quote }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
           {{- end }}
         {{- end }}
         - name: FN_DB_PASSWD

--- a/fn/values.yaml
+++ b/fn/values.yaml
@@ -17,11 +17,33 @@ fnlb:
 
 fnserver:
   image: fnproject/fnserver:latest
-  logLevel: info
   resources: {}
   nodeSelector: {}
   tolerations: []
-
+  env: 
+    FN_DB_URL: "mysql://fnapp:$(FN_DB_PASSWD)@tcp($(FN_DB_HOST):3306)/fndb"
+    FN_MQ_URL: "redis://$(FN_MQ_HOST):6379/" 
+    FN_PORT: "80"
+    FN_LOG_LEVEL: "info"
+    FN_LOG_DEST: ""
+    FN_LOG_PREFIX: ""
+    FN_LOGSTORE_URL: ""
+    FN_API_CORS_ORIGINS: ""
+    FN_API_CORS_HEADERS: ""
+    FN_FREEZE_IDLE_MSECS: ""
+    FN_EJECT_IDLE_MSECS: ""
+    FN_MAX_RESPONSE_SIZE: ""
+    FN_RUNNER_API_URL: ""
+    FN_RUNNER_ADDRESSES: ""
+    FN_NODE_TYPE: ""
+    FN_GRPC_PORT: ""
+    FN_ZIPKIN_URL: ""
+    FN_JAEGER_URL: ""
+    FN_NODE_CERT: ""
+    FN_NODE_CERT_KEY: ""
+    FN_NODE_CERT_AUTHORITY: ""
+    FN_PROCESS_COLLECTOR_LIST: ""
+    FN_PLACER: ""
 
 ui:
   enabled: true


### PR DESCRIPTION
Setting the environment variables in the container if they are provided. This allows users to provide their own e.g. DB_URL, CORS settings, etc. 

Fixes #25 