### PR TITLE
Fix link to 'values.yaml' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install chart dependencies from [requirements.yaml](./fn/requirements.yaml):
 helm dep build fn
 ```
 
-The default chart will install fn as a private service inside your cluster with ephemeral storage, to configure a public endpoint and persistent storage you should look at [values.yaml](values.yaml) and modify the default settings. An example for Oracle Cloud Infrastructure is [here](examples/oci).
+The default chart will install fn as a private service inside your cluster with ephemeral storage, to configure a public endpoint and persistent storage you should look at [values.yaml](fn/values.yaml) and modify the default settings. An example for Oracle Cloud Infrastructure is [here](examples/oci).
 
 To install the chart with the release name `my-release`:
 


### PR DESCRIPTION
Fixed broken link to [values.yaml](https://github.com/fnproject/fn-helm/blob/master/fn/values.yaml) in [README.md](https://github.com/fnproject/fn-helm/blob/master/README.md)
This catches up on 844821477bf1e77f1f795b764ece96aeab4b7284.