### PR TITLE
Fix TLS ingress hosts and Fn public load balancer host

### DIFF
--- a/fn/templates/fn-deployment.yaml
+++ b/fn/templates/fn-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           - name: FN_NODE_TYPE
             value: "api"
           - name: FN_PUBLIC_LB_URL
-            value: http://{{ template "fullname" . }}{{ .Values.fn_lb_runner.service.ingress_hostname }}:{{ .Values.fn_lb_runner.service.port }}
+            value: http://{{ template "fullname" . }}.{{ .Values.fn_lb_runner.service.ingress_hostname }}:{{ .Values.fn_lb_runner.service.port }}
           {{- range $key, $value := .Values.fn_api.env }}
             {{- if $value }}
           - name: {{ $key }}

--- a/fn/templates/fn-deployment.yaml
+++ b/fn/templates/fn-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           - name: FN_NODE_TYPE
             value: "api"
           - name: FN_PUBLIC_LB_URL
-            value: http://{{ .Values.fn_lb_runner.service.ingress_hostname }}:{{ .Values.fn_lb_runner.service.port }}
+            value: http://{{ template "fullname" . }}{{ .Values.fn_lb_runner.service.ingress_hostname }}:{{ .Values.fn_lb_runner.service.port }}
           {{- range $key, $value := .Values.fn_api.env }}
             {{- if $value }}
           - name: {{ $key }}

--- a/fn/templates/fn-ingress.yaml
+++ b/fn/templates/fn-ingress.yaml
@@ -47,7 +47,7 @@ spec:
   tls:
     - secretName: {{ .Values.tls.secret_reference }}
       hosts:
-        - {{ .Values.fn_api.service.ingress_hostname }}
-        - {{ .Values.fn_lb_runner.service.ingress_hostname }}
+        - {{ template "fullname" . }}{{ .Values.fn_api.service.ingress_hostname }}
+        - {{ template "fullname" . }}{{ .Values.fn_lb_runner.service.ingress_hostname }}
   {{- end -}}
 {{- end -}}

--- a/fn/templates/fn-ingress.yaml
+++ b/fn/templates/fn-ingress.yaml
@@ -47,7 +47,7 @@ spec:
   tls:
     - secretName: {{ .Values.tls.secret_reference }}
       hosts:
-        - {{ template "fullname" . }}{{ .Values.fn_api.service.ingress_hostname }}
-        - {{ template "fullname" . }}{{ .Values.fn_lb_runner.service.ingress_hostname }}
+        - {{ template "fullname" . }}.{{ .Values.fn_api.service.ingress_hostname }}
+        - {{ template "fullname" . }}.{{ .Values.fn_lb_runner.service.ingress_hostname }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Missed a couple after the last patch landed. Noticed I was unable to invoke functions through CLI and this is why.